### PR TITLE
Volunteer schedule

### DIFF
--- a/PantryLink/PantryLink/Models/PantryModel.swift
+++ b/PantryLink/PantryLink/Models/PantryModel.swift
@@ -16,6 +16,7 @@ struct Pantry: Codable, Identifiable {
     let email: String?
     let phone_number: String?
     let website: String?
+    let schedule_settings: ScheduleSettings?
     var id: String {_id}
 }
 

--- a/PantryLink/PantryLink/Models/ScheduleModel.swift
+++ b/PantryLink/PantryLink/Models/ScheduleModel.swift
@@ -7,9 +7,41 @@
 
 import Foundation
 
+// New format response: { date: string, schedule: { shifts: [...], general_volunteers: [...] } }
 struct ScheduleResponse: Codable {
     let date: String
-    let schedule: [Shift]
+    let schedule: ScheduleData
+    
+    // Custom decoder to handle both new format (object) and legacy format (array)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(String.self, forKey: .date)
+        
+        // Try to decode as new format first
+        if let scheduleData = try? container.decode(ScheduleData.self, forKey: .schedule) {
+            schedule = scheduleData
+        } else if let legacyShifts = try? container.decode([Shift].self, forKey: .schedule) {
+            // Legacy format: array of shifts
+            schedule = ScheduleData(shifts: legacyShifts, general_volunteers: [])
+        } else {
+            // Empty schedule
+            schedule = ScheduleData(shifts: [], general_volunteers: [])
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case date, schedule
+    }
+}
+
+struct ScheduleData: Codable {
+    let shifts: [Shift]
+    let general_volunteers: [ShiftVolunteer]
+    
+    init(shifts: [Shift] = [], general_volunteers: [ShiftVolunteer] = []) {
+        self.shifts = shifts
+        self.general_volunteers = general_volunteers
+    }
 }
 
 struct Shift: Codable, Identifiable {
@@ -21,11 +53,48 @@ struct Shift: Codable, Identifiable {
 
 struct ShiftVolunteer: Codable, Identifiable {
     let name: String
-    let role: String
     let email: String?
     let username: String?
     
-    var id: String { "\(name)-\(role)" }
+    var id: String { "\(name)-\(username ?? "")" }
+    
+    init(name: String, email: String? = nil, username: String? = nil) {
+        self.name = name
+        self.email = email
+        self.username = username
+    }
+}
+
+struct ScheduleSettings: Codable {
+    let schedulingEnabled: Bool?
+    let openDays: [Int]?
+    let excludedDates: [String]?
+    let useDefaultSchedule: Bool?
+    let defaultSchedule: [Shift]?
+    
+    var isSchedulingEnabled: Bool { schedulingEnabled ?? true }
+    var effectiveOpenDays: [Int] { openDays ?? [1, 2, 3, 4, 5] }  // Mon-Fri default
+    var effectiveExcludedDates: [String] { excludedDates ?? [] }
+}
+
+struct UserWeekScheduleItem: Codable, Identifiable {
+    let pantry_id: String
+    let pantry_name: String
+    let date: String
+    let shift: String
+    let time: String
+    
+    var id: String { "\(pantry_id)-\(date)-\(shift)" }
+}
+
+struct UserWeekScheduleResponse: Codable {
+    let schedules: [UserWeekScheduleItem]
+}
+
+struct UserConflictResponse: Codable {
+    let scheduled: Bool
+    let pantry_name: String?
+    let pantry_id: String?
 }
 
 struct TodaysScheduleItem: Identifiable {
@@ -35,6 +104,5 @@ struct TodaysScheduleItem: Identifiable {
     let pantryAddress: String
     let shift: String
     let time: String
-    let role: String
     let date: String
 }

--- a/PantryLink/PantryLink/Views/Home/LocalPantryView.swift
+++ b/PantryLink/PantryLink/Views/Home/LocalPantryView.swift
@@ -173,7 +173,7 @@ struct LocalPantryView: View {
         .onAppear{
             location.checkLocationAuthorization()
         }
-        .onChange(of: location.locationReady) { newValue in
+        .onChange(of: location.locationReady) { _, newValue in
             if newValue {
                 location.findPantries()
             }

--- a/PantryLink/PantryLink/Views/Home/StreamView.swift
+++ b/PantryLink/PantryLink/Views/Home/StreamView.swift
@@ -151,8 +151,8 @@ struct StreamView: View {
     StreamView(streamViewViewModel: StreamViewViewModel(), pantries: [
         Pantry(_id:"68ed1581783104e82a2790e9",name: "Princeton Mobile", stock: [], address:"1234 main street", stream:[
             StreamAlert(date: "10/25/2023", message: "Hi world")
-        ], email: "contact@princeton.org", phone_number: "(555) 123-4567", website: nil), 
-        Pantry(_id: "id", name: "Hillsborough CAN", stock: [], address: "273 Kelvin street", stream:[StreamAlert(date: "10/24/23", message: "food information")], email: nil, phone_number: nil, website: nil)
+        ], email: "contact@princeton.org", phone_number: "(555) 123-4567", website: nil, schedule_settings: nil), 
+        Pantry(_id: "id", name: "Hillsborough CAN", stock: [], address: "273 Kelvin street", stream:[StreamAlert(date: "10/24/23", message: "food information")], email: nil, phone_number: nil, website: nil, schedule_settings: nil)
     ])
 }
 

--- a/PantryLink/PantryLink/Views/Serve/PantryScheduleDetailView.swift
+++ b/PantryLink/PantryLink/Views/Serve/PantryScheduleDetailView.swift
@@ -13,15 +13,13 @@ struct PantryScheduleDetailView: View {
     @Environment(\.dismiss) private var dismiss
     
     @State private var selectedDate = Date()
-    @State private var shifts: [Shift] = []
+    @State private var scheduleData: ScheduleData = ScheduleData()
     @State private var isLoading = false
-    @State private var showAddSheet = false
-    @State private var selectedShiftId: Int?
-    @State private var userRole = ""
     @State private var showAlert = false
     @State private var alertMessage = ""
-    @State private var showEditSheet = false
-    @State private var editingVolunteerShiftId: Int?
+    
+    // Available dates for the custom picker
+    @State private var availableDates: [DateOption] = []
     
     var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
@@ -29,23 +27,25 @@ struct PantryScheduleDetailView: View {
         return formatter
     }
     
-    var displayDateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        return formatter
+    var settings: ScheduleSettings {
+        pantry.schedule_settings ?? ScheduleSettings(
+            schedulingEnabled: true,
+            openDays: [1, 2, 3, 4, 5],
+            excludedDates: [],
+            useDefaultSchedule: false,
+            defaultSchedule: nil
+        )
     }
     
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                // Date Selector
-                DatePicker("Select Date", selection: $selectedDate, displayedComponents: .date)
-                    .datePickerStyle(.compact)
-                    .padding()
-                    .background(Colors.flexibleLightGray.opacity(0.2))
-                    .onChange(of: selectedDate) { _ in
-                        fetchSchedule()
-                    }
+                // Custom Date Selector
+                CustomDateSelector(
+                    selectedDate: $selectedDate,
+                    availableDates: availableDates,
+                    onDateChange: { fetchSchedule() }
+                )
                 
                 Divider()
                 
@@ -54,39 +54,38 @@ struct PantryScheduleDetailView: View {
                     if isLoading {
                         ProgressView()
                             .frame(maxWidth: .infinity, minHeight: 300)
-                    } else if shifts.isEmpty {
-                        VStack(spacing: 16) {
-                            Text("No shifts have been created")
-                                .font(.headline)
-                                .foregroundColor(Colors.flexibleDarkGray)
-                                .padding(.top, 100)
-                            
-                            Text("You can still add yourself to volunteer for this day")
-                                .font(.subheadline)
-                                .foregroundColor(Colors.flexibleDarkGray)
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal, 40)
-                        }
                     } else {
                         VStack(spacing: 16) {
-                            ForEach(shifts) { shift in
-                                ShiftCard(
-                                    shift: shift,
-                                    currentUsername: userManager.currentUser?.username ?? "",
-                                    onEdit: {
-                                        editingVolunteerShiftId = shift.id
-                                        if let volunteer = shift.volunteers.first(where: {
-                                            $0.username?.lowercased() == userManager.currentUser?.username.lowercased()
-                                        }) {
-                                            userRole = volunteer.role
-                                            showEditSheet = true
-                                        }
-                                    },
-                                    onRemove: {
-                                        removeFromShift(shiftId: shift.id)
-                                    }
-                                )
+                            // Shifts
+                            if scheduleData.shifts.isEmpty {
+                                VStack(spacing: 16) {
+                                    Text("No shifts available for this day")
+                                        .font(.headline)
+                                        .foregroundColor(Colors.flexibleDarkGray)
+                                        .padding(.top, 40)
+                                    
+                                    Text("The pantry hasn't set up shifts yet")
+                                        .font(.subheadline)
+                                        .foregroundColor(Colors.flexibleDarkGray)
+                                }
+                            } else {
+                                ForEach(scheduleData.shifts) { shift in
+                                    ShiftCard(
+                                        shift: shift,
+                                        currentUsername: userManager.currentUser?.username ?? "",
+                                        onAddSelf: { addSelfToShift(shiftId: shift.id) },
+                                        onRemoveSelf: { removeSelfFromShift(shiftId: shift.id) }
+                                    )
+                                }
                             }
+                            
+                            // General Volunteers Section
+                            GeneralVolunteersCard(
+                                volunteers: scheduleData.general_volunteers,
+                                currentUsername: userManager.currentUser?.username ?? "",
+                                onAddSelf: { addSelfToGeneral() },
+                                onRemoveSelf: { removeSelfFromGeneral() }
+                            )
                         }
                         .padding()
                     }
@@ -100,58 +99,44 @@ struct PantryScheduleDetailView: View {
                         dismiss()
                     }
                 }
-                
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {
-                        if shifts.isEmpty {
-                            // No shifts exist, add directly
-                            selectedShiftId = nil
-                            userRole = ""
-                            showAddSheet = true
-                        } else {
-                            // Shifts exist, let user select
-                            selectedShiftId = nil
-                            userRole = ""
-                            showAddSheet = true
-                        }
-                    }) {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.title3)
-                            .foregroundColor(Colors.flexibleOrange)
-                    }
-                }
             }
             .onAppear {
+                setupAvailableDates()
                 fetchSchedule()
-            }
-            .sheet(isPresented: $showAddSheet) {
-                AddToScheduleSheet(
-                    shifts: shifts,
-                    selectedShiftId: $selectedShiftId,
-                    userRole: $userRole,
-                    onSave: {
-                        addToSchedule()
-                    }
-                )
-            }
-            .sheet(isPresented: $showEditSheet) {
-                EditScheduleSheet(
-                    userRole: $userRole,
-                    onSave: {
-                        updateSchedule()
-                    },
-                    onRemove: {
-                        if let shiftId = editingVolunteerShiftId {
-                            removeFromShift(shiftId: shiftId)
-                        }
-                    }
-                )
             }
             .alert("Schedule Update", isPresented: $showAlert) {
                 Button("OK", role: .cancel) { }
             } message: {
                 Text(alertMessage)
             }
+        }
+    }
+    
+    private func setupAvailableDates() {
+        var dates: [DateOption] = []
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        
+        for i in 0..<14 {
+            guard let date = calendar.date(byAdding: .day, value: i, to: today) else { continue }
+            let dateKey = dateFormatter.string(from: date)
+            
+            // Determine if date is available
+            let dayOfWeek = (calendar.component(.weekday, from: date) + 5) % 7 // Convert to JS format (0=Sun)
+            let jsWeekday = calendar.component(.weekday, from: date) - 1 // 0=Sun
+            
+            let isOpenDay = settings.effectiveOpenDays.contains(jsWeekday)
+            let isExcluded = settings.effectiveExcludedDates.contains(dateKey)
+            let isAvailable = settings.isSchedulingEnabled && isOpenDay && !isExcluded
+            
+            dates.append(DateOption(date: date, dateKey: dateKey, isAvailable: isAvailable))
+        }
+        
+        availableDates = dates
+        
+        // Select first available date
+        if let firstAvailable = dates.first(where: { $0.isAvailable }) {
+            selectedDate = firstAvailable.date
         }
     }
     
@@ -175,18 +160,52 @@ struct PantryScheduleDetailView: View {
             do {
                 let scheduleResponse = try JSONDecoder().decode(ScheduleResponse.self, from: data)
                 DispatchQueue.main.async {
-                    self.shifts = scheduleResponse.schedule
+                    self.scheduleData = scheduleResponse.schedule
                 }
             } catch {
                 print("Error decoding schedule: \(error)")
                 DispatchQueue.main.async {
-                    self.shifts = []
+                    self.scheduleData = ScheduleData()
                 }
             }
         }.resume()
     }
     
-    private func addToSchedule() {
+    // Check if user is already scheduled elsewhere
+    private func checkConflict(completion: @escaping (UserConflictResponse?) -> Void) {
+        guard let username = userManager.currentUser?.username else {
+            completion(nil)
+            return
+        }
+        
+        let dateKey = dateFormatter.string(from: selectedDate)
+        let urlString = "https://yellow-team.onrender.com/pantry/check-user-conflict?username=\(username)&date=\(dateKey)&exclude_pantry_id=\(pantry._id)"
+        
+        guard let url = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? urlString) else {
+            completion(nil)
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            guard let data = data, error == nil else {
+                completion(nil)
+                return
+            }
+            
+            do {
+                let result = try JSONDecoder().decode(UserConflictResponse.self, from: data)
+                DispatchQueue.main.async {
+                    completion(result)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+            }
+        }.resume()
+    }
+    
+    private func addSelfToShift(shiftId: Int) {
         guard let username = userManager.currentUser?.username,
               let firstName = userManager.currentUser?.first_name,
               let lastName = userManager.currentUser?.last_name,
@@ -196,126 +215,279 @@ struct PantryScheduleDetailView: View {
             return
         }
         
-        let dateKey = dateFormatter.string(from: selectedDate)
+        // Check if already in this shift
+        if let shift = scheduleData.shifts.first(where: { $0.id == shiftId }),
+           shift.volunteers.contains(where: { $0.username?.lowercased() == username.lowercased() }) {
+            alertMessage = "You're already signed up for this shift"
+            showAlert = true
+            return
+        }
         
-        var updatedShifts = shifts
-        let volunteerName = "\(firstName) \(lastName)"
-        
-        let newVolunteer = ShiftVolunteer(
-            name: volunteerName,
-            role: userRole,
-            email: email,
-            username: username
-        )
-        
-        if let shiftId = selectedShiftId {
-            // Add to specific shift
-            if let index = updatedShifts.firstIndex(where: { $0.id == shiftId }) {
-                var updatedShift = updatedShifts[index]
-                var volunteers = updatedShift.volunteers
+        // Check for conflicts at other pantries
+        checkConflict { conflict in
+            if let conflict = conflict, conflict.scheduled, let pantryName = conflict.pantry_name {
+                self.alertMessage = "You're already scheduled at \(pantryName) on this day. You can only volunteer at one pantry per day."
+                self.showAlert = true
+                return
+            }
+            
+            // Also check if already in another shift or general at THIS pantry
+            let isInOtherShift = self.scheduleData.shifts.contains { shift in
+                shift.id != shiftId && shift.volunteers.contains { $0.username?.lowercased() == username.lowercased() }
+            }
+            let isInGeneral = self.scheduleData.general_volunteers.contains { $0.username?.lowercased() == username.lowercased() }
+            
+            if isInOtherShift || isInGeneral {
+                self.alertMessage = "You're already signed up for this day. Remove yourself first before switching."
+                self.showAlert = true
+                return
+            }
+            
+            let volunteerName = "\(firstName) \(lastName)"
+            let newVolunteer = ShiftVolunteer(name: volunteerName, email: email, username: username)
+            
+            var updatedSchedule = self.scheduleData
+            if let index = updatedSchedule.shifts.firstIndex(where: { $0.id == shiftId }) {
+                var volunteers = updatedSchedule.shifts[index].volunteers
                 volunteers.append(newVolunteer)
-                updatedShifts[index] = Shift(
-                    id: updatedShift.id,
-                    time: updatedShift.time,
-                    shift: updatedShift.shift,
+                let updatedShift = Shift(
+                    id: updatedSchedule.shifts[index].id,
+                    time: updatedSchedule.shifts[index].time,
+                    shift: updatedSchedule.shifts[index].shift,
                     volunteers: volunteers
                 )
+                var shifts = updatedSchedule.shifts
+                shifts[index] = updatedShift
+                updatedSchedule = ScheduleData(shifts: shifts, general_volunteers: updatedSchedule.general_volunteers)
             }
-        } else if shifts.isEmpty {
-            // No shifts exist, create a general volunteer entry
-            updatedShifts = [Shift(
-                id: 1,
-                time: "Available",
-                shift: "General Volunteer",
-                volunteers: [newVolunteer]
-            )]
+            
+            self.saveSchedule(updatedSchedule: updatedSchedule)
         }
-        
-        saveSchedule(updatedShifts: updatedShifts, dateKey: dateKey)
     }
     
-    private func updateSchedule() {
-        guard let username = userManager.currentUser?.username,
-              let shiftId = editingVolunteerShiftId else { return }
-        
-        let dateKey = dateFormatter.string(from: selectedDate)
-        var updatedShifts = shifts
-        
-        if let shiftIndex = updatedShifts.firstIndex(where: { $0.id == shiftId }),
-           let volunteerIndex = updatedShifts[shiftIndex].volunteers.firstIndex(where: {
-               $0.username?.lowercased() == username.lowercased()
-           }) {
-            var volunteers = updatedShifts[shiftIndex].volunteers
-            volunteers[volunteerIndex] = ShiftVolunteer(
-                name: volunteers[volunteerIndex].name,
-                role: userRole,
-                email: volunteers[volunteerIndex].email,
-                username: volunteers[volunteerIndex].username
-            )
-            updatedShifts[shiftIndex] = Shift(
-                id: updatedShifts[shiftIndex].id,
-                time: updatedShifts[shiftIndex].time,
-                shift: updatedShifts[shiftIndex].shift,
-                volunteers: volunteers
-            )
-        }
-        
-        saveSchedule(updatedShifts: updatedShifts, dateKey: dateKey)
-    }
-    
-    private func removeFromShift(shiftId: Int) {
+    private func removeSelfFromShift(shiftId: Int) {
         guard let username = userManager.currentUser?.username else { return }
         
-        let dateKey = dateFormatter.string(from: selectedDate)
-        var updatedShifts = shifts
-        
-        if let shiftIndex = updatedShifts.firstIndex(where: { $0.id == shiftId }) {
-            var volunteers = updatedShifts[shiftIndex].volunteers.filter {
+        var updatedSchedule = scheduleData
+        if let index = updatedSchedule.shifts.firstIndex(where: { $0.id == shiftId }) {
+            let volunteers = updatedSchedule.shifts[index].volunteers.filter {
                 $0.username?.lowercased() != username.lowercased()
             }
-            updatedShifts[shiftIndex] = Shift(
-                id: updatedShifts[shiftIndex].id,
-                time: updatedShifts[shiftIndex].time,
-                shift: updatedShifts[shiftIndex].shift,
+            let updatedShift = Shift(
+                id: updatedSchedule.shifts[index].id,
+                time: updatedSchedule.shifts[index].time,
+                shift: updatedSchedule.shifts[index].shift,
                 volunteers: volunteers
             )
+            var shifts = updatedSchedule.shifts
+            shifts[index] = updatedShift
+            updatedSchedule = ScheduleData(shifts: shifts, general_volunteers: updatedSchedule.general_volunteers)
         }
         
-        saveSchedule(updatedShifts: updatedShifts, dateKey: dateKey)
+        saveSchedule(updatedSchedule: updatedSchedule)
     }
     
-    private func saveSchedule(updatedShifts: [Shift], dateKey: String) {
+    private func addSelfToGeneral() {
+        guard let username = userManager.currentUser?.username,
+              let firstName = userManager.currentUser?.first_name,
+              let lastName = userManager.currentUser?.last_name,
+              let email = userManager.currentUser?.email else {
+            alertMessage = "User information not available"
+            showAlert = true
+            return
+        }
+        
+        // Check if already in general
+        if scheduleData.general_volunteers.contains(where: { $0.username?.lowercased() == username.lowercased() }) {
+            alertMessage = "You're already signed up as a general volunteer"
+            showAlert = true
+            return
+        }
+        
+        // Check for conflicts
+        checkConflict { conflict in
+            if let conflict = conflict, conflict.scheduled, let pantryName = conflict.pantry_name {
+                self.alertMessage = "You're already scheduled at \(pantryName) on this day. You can only volunteer at one pantry per day."
+                self.showAlert = true
+                return
+            }
+            
+            // Check if already in a shift at THIS pantry
+            let isInShift = self.scheduleData.shifts.contains { shift in
+                shift.volunteers.contains { $0.username?.lowercased() == username.lowercased() }
+            }
+            
+            if isInShift {
+                self.alertMessage = "You're already signed up for a shift. Remove yourself first before switching to general."
+                self.showAlert = true
+                return
+            }
+            
+            let volunteerName = "\(firstName) \(lastName)"
+            let newVolunteer = ShiftVolunteer(name: volunteerName, email: email, username: username)
+            
+            var generalVolunteers = self.scheduleData.general_volunteers
+            generalVolunteers.append(newVolunteer)
+            let updatedSchedule = ScheduleData(shifts: self.scheduleData.shifts, general_volunteers: generalVolunteers)
+            
+            self.saveSchedule(updatedSchedule: updatedSchedule)
+        }
+    }
+    
+    private func removeSelfFromGeneral() {
+        guard let username = userManager.currentUser?.username else { return }
+        
+        let generalVolunteers = scheduleData.general_volunteers.filter {
+            $0.username?.lowercased() != username.lowercased()
+        }
+        let updatedSchedule = ScheduleData(shifts: scheduleData.shifts, general_volunteers: generalVolunteers)
+        
+        saveSchedule(updatedSchedule: updatedSchedule)
+    }
+    
+    private func saveSchedule(updatedSchedule: ScheduleData) {
+        let dateKey = dateFormatter.string(from: selectedDate)
         guard let url = URL(string: "https://yellow-team.onrender.com/pantry/\(pantry._id)/schedule/\(dateKey)") else { return }
         
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let payload: [String: Any] = ["schedule": try! JSONSerialization.jsonObject(with: JSONEncoder().encode(updatedShifts))]
-        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
-        
-        URLSession.shared.dataTask(with: request) { _, response, error in
-            DispatchQueue.main.async {
-                if error != nil {
-                    alertMessage = "Failed to update schedule"
-                    showAlert = true
-                } else {
-                    alertMessage = "Schedule updated successfully"
-                    showAlert = true
-                    fetchSchedule()
+        do {
+            // Create payload in new format
+            let payload: [String: Any] = [
+                "schedule": [
+                    "shifts": updatedSchedule.shifts.map { shift in
+                        [
+                            "id": shift.id,
+                            "time": shift.time,
+                            "shift": shift.shift,
+                            "volunteers": shift.volunteers.map { vol in
+                                ["name": vol.name, "email": vol.email ?? "", "username": vol.username ?? ""]
+                            }
+                        ]
+                    },
+                    "general_volunteers": updatedSchedule.general_volunteers.map { vol in
+                        ["name": vol.name, "email": vol.email ?? "", "username": vol.username ?? ""]
+                    }
+                ]
+            ]
+            
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        self.alertMessage = "Failed to update schedule: \(error.localizedDescription)"
+                        self.showAlert = true
+                    } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                        self.alertMessage = "Schedule updated!"
+                        self.showAlert = true
+                        self.fetchSchedule()
+                    } else {
+                        self.alertMessage = "Failed to update schedule"
+                        self.showAlert = true
+                    }
                 }
-                showAddSheet = false
-                showEditSheet = false
-            }
-        }.resume()
+            }.resume()
+        } catch {
+            alertMessage = "Failed to encode schedule"
+            showAlert = true
+        }
     }
 }
 
+// MARK: - Date Option Model
+struct DateOption: Identifiable {
+    let date: Date
+    let dateKey: String
+    let isAvailable: Bool
+    
+    var id: String { dateKey }
+    
+    var displayText: String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) {
+            return "Today"
+        } else if calendar.isDateInTomorrow(date) {
+            return "Tomorrow"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "EEE d"
+            return formatter.string(from: date)
+        }
+    }
+}
+
+// MARK: - Custom Date Selector
+struct CustomDateSelector: View {
+    @Binding var selectedDate: Date
+    let availableDates: [DateOption]
+    let onDateChange: () -> Void
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(availableDates) { option in
+                    DateButton(
+                        option: option,
+                        isSelected: Calendar.current.isDate(selectedDate, inSameDayAs: option.date),
+                        onTap: {
+                            if option.isAvailable {
+                                selectedDate = option.date
+                                onDateChange()
+                            }
+                        }
+                    )
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+        }
+        .background(Colors.flexibleLightGray.opacity(0.2))
+    }
+}
+
+struct DateButton: View {
+    let option: DateOption
+    let isSelected: Bool
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 4) {
+                Text(option.displayText)
+                    .font(.caption)
+                    .fontWeight(isSelected ? .bold : .regular)
+                
+                let formatter = DateFormatter()
+                let _ = formatter.dateFormat = "MMM"
+                Text(formatter.string(from: option.date))
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                isSelected ? Colors.flexibleOrange :
+                option.isAvailable ? Colors.flexibleWhite : Colors.flexibleLightGray
+            )
+            .foregroundColor(
+                isSelected ? Colors.flexibleWhite :
+                option.isAvailable ? Colors.flexibleBlack : Colors.flexibleDarkGray
+            )
+            .cornerRadius(8)
+            .opacity(option.isAvailable ? 1.0 : 0.5)
+        }
+        .disabled(!option.isAvailable)
+    }
+}
+
+// MARK: - Shift Card
 struct ShiftCard: View {
     let shift: Shift
     let currentUsername: String
-    let onEdit: () -> Void
-    let onRemove: () -> Void
+    let onAddSelf: () -> Void
+    let onRemoveSelf: () -> Void
     
     var isUserInShift: Bool {
         shift.volunteers.contains(where: { $0.username?.lowercased() == currentUsername.lowercased() })
@@ -337,18 +509,32 @@ struct ShiftCard: View {
                 
                 Spacer()
                 
+                // Add/Remove button
                 if isUserInShift {
-                    Menu {
-                        Button(action: onEdit) {
-                            Label("Edit Role", systemImage: "pencil")
+                    Button(action: onRemoveSelf) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "minus.circle.fill")
+                            Text("Leave")
                         }
-                        Button(role: .destructive, action: onRemove) {
-                            Label("Remove", systemImage: "trash")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(16)
+                    }
+                } else {
+                    Button(action: onAddSelf) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "plus.circle.fill")
+                            Text("Join")
                         }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .font(.title3)
-                            .foregroundColor(Colors.flexibleOrange)
+                        .font(.caption)
+                        .foregroundColor(Colors.flexibleOrange)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Colors.flexibleOrange.opacity(0.1))
+                        .cornerRadius(16)
                     }
                 }
             }
@@ -356,11 +542,11 @@ struct ShiftCard: View {
             if !shift.volunteers.isEmpty {
                 Divider()
                 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Volunteers:")
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Volunteers (\(shift.volunteers.count))")
                         .font(.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(Colors.flexibleBlack)
+                        .foregroundColor(Colors.flexibleDarkGray)
                     
                     ForEach(shift.volunteers) { volunteer in
                         HStack {
@@ -373,15 +559,19 @@ struct ShiftCard: View {
                                 .font(.subheadline)
                                 .foregroundColor(Colors.flexibleBlack)
                             
-                            Text("•")
-                                .foregroundColor(Colors.flexibleDarkGray)
-                            
-                            Text(volunteer.role)
-                                .font(.subheadline)
-                                .foregroundColor(Colors.flexibleDarkGray)
+                            if volunteer.username?.lowercased() == currentUsername.lowercased() {
+                                Text("(You)")
+                                    .font(.caption)
+                                    .foregroundColor(Colors.flexibleOrange)
+                            }
                         }
                     }
                 }
+            } else {
+                Text("No volunteers yet - be the first!")
+                    .font(.caption)
+                    .foregroundColor(Colors.flexibleDarkGray)
+                    .padding(.top, 4)
             }
         }
         .padding()
@@ -394,92 +584,99 @@ struct ShiftCard: View {
     }
 }
 
-struct AddToScheduleSheet: View {
-    let shifts: [Shift]
-    @Binding var selectedShiftId: Int?
-    @Binding var userRole: String
-    let onSave: () -> Void
-    @Environment(\.dismiss) private var dismiss
+// MARK: - General Volunteers Card
+struct GeneralVolunteersCard: View {
+    let volunteers: [ShiftVolunteer]
+    let currentUsername: String
+    let onAddSelf: () -> Void
+    let onRemoveSelf: () -> Void
+    
+    var isUserInGeneral: Bool {
+        volunteers.contains(where: { $0.username?.lowercased() == currentUsername.lowercased() })
+    }
     
     var body: some View {
-        NavigationStack {
-            Form {
-                if !shifts.isEmpty {
-                    Section("Select Shift") {
-                        Picker("Shift", selection: $selectedShiftId) {
-                            Text("Select a shift").tag(nil as Int?)
-                            ForEach(shifts) { shift in
-                                Text("\(shift.shift) - \(shift.time)").tag(shift.id as Int?)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("General Volunteers")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(Colors.flexibleBlack)
+                    
+                    Text("Available throughout the day")
+                        .font(.subheadline)
+                        .foregroundColor(Colors.flexibleDarkGray)
+                }
+                
+                Spacer()
+                
+                // Add/Remove button
+                if isUserInGeneral {
+                    Button(action: onRemoveSelf) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "minus.circle.fill")
+                            Text("Leave")
+                        }
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(16)
+                    }
+                } else {
+                    Button(action: onAddSelf) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "plus.circle.fill")
+                            Text("Join")
+                        }
+                        .font(.caption)
+                        .foregroundColor(Colors.flexibleGreen)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Colors.flexibleGreen.opacity(0.1))
+                        .cornerRadius(16)
+                    }
+                }
+            }
+            
+            if !volunteers.isEmpty {
+                Divider()
+                
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(volunteers) { volunteer in
+                        HStack {
+                            Circle()
+                                .fill(volunteer.username?.lowercased() == currentUsername.lowercased() ?
+                                      Colors.flexibleGreen : Colors.flexibleLightGray)
+                                .frame(width: 6, height: 6)
+                            
+                            Text(volunteer.name)
+                                .font(.subheadline)
+                                .foregroundColor(Colors.flexibleBlack)
+                            
+                            if volunteer.username?.lowercased() == currentUsername.lowercased() {
+                                Text("(You)")
+                                    .font(.caption)
+                                    .foregroundColor(Colors.flexibleGreen)
                             }
                         }
                     }
                 }
-                
-                Section("Your Role") {
-                    TextField("Enter your role (e.g., Food Sorter, Delivery)", text: $userRole)
-                }
-            }
-            .navigationTitle("Add to Schedule")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
-                
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") {
-                        if shifts.isEmpty || selectedShiftId != nil {
-                            onSave()
-                        }
-                    }
-                    .disabled(userRole.isEmpty || (!shifts.isEmpty && selectedShiftId == nil))
-                }
+            } else {
+                Text("No general volunteers yet")
+                    .font(.caption)
+                    .foregroundColor(Colors.flexibleDarkGray)
+                    .padding(.top, 4)
             }
         }
-    }
-}
-
-struct EditScheduleSheet: View {
-    @Binding var userRole: String
-    let onSave: () -> Void
-    let onRemove: () -> Void
-    @Environment(\.dismiss) private var dismiss
-    
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Your Role") {
-                    TextField("Enter your role", text: $userRole)
-                }
-                
-                Section {
-                    Button(role: .destructive, action: {
-                        onRemove()
-                        dismiss()
-                    }) {
-                        Text("Remove from Schedule")
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-            }
-            .navigationTitle("Edit Schedule")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
-                
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        onSave()
-                    }
-                    .disabled(userRole.isEmpty)
-                }
-            }
-        }
+        .padding()
+        .background(isUserInGeneral ? Colors.flexibleGreen.opacity(0.1) : Color(UIColor.systemGray6))
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isUserInGeneral ? Colors.flexibleGreen : Colors.flexibleLightGray, lineWidth: isUserInGeneral ? 1.5 : 1)
+        )
     }
 }

--- a/PantryLink/PantryLink/Views/Stock/PantryDetailView.swift
+++ b/PantryLink/PantryLink/Views/Stock/PantryDetailView.swift
@@ -725,7 +725,8 @@ struct PantryInfoPopUpView: View {
             stream: nil,
             email: "contact@montgomerypantry.org",
             phone_number: "(908) 555-1234",
-            website: "https://montgomerypantry.org"
+            website: "https://montgomerypantry.org",
+            schedule_settings: nil
         )
     )
 }

--- a/PantryLink/PantryLink/Views/Stock/SearchPantryView.swift
+++ b/PantryLink/PantryLink/Views/Stock/SearchPantryView.swift
@@ -428,7 +428,7 @@ struct BasicPantryCard: View {
                     
                     // Address
                     if let street = mapItem.placemark.thoroughfare,
-                       let zip = mapItem.placemark.postalCode {
+                       let _ = mapItem.placemark.postalCode {
                         HStack(spacing: 4) {
                             Image(systemName: "location.fill")
                                 .font(.caption)

--- a/server/app/models/pantry.py
+++ b/server/app/models/pantry.py
@@ -1,9 +1,116 @@
 from flask_pymongo import PyMongo
-from datetime import datetime
+from datetime import datetime, timedelta
 
 class pantry_model: 
     def __init__(self, mongo: PyMongo):
         self.collection = mongo.cx["test"]["pantries"]
+    
+    def get_user_week_schedule(self, username: str, from_date: str, to_date: str):
+        """
+        Get all schedule entries for a user across all pantries within a date range.
+        Returns list of {pantry_id, pantry_name, date, shift (or 'General'), time}.
+        """
+        # Find all pantries and check their schedules for this user
+        pantries = list(self.collection.find({}, {"_id": 1, "name": 1, "schedules": 1}))
+        results = []
+        
+        for pantry in pantries:
+            pantry_id = str(pantry["_id"])
+            pantry_name = pantry.get("name", "Unknown Pantry")
+            schedules = pantry.get("schedules", {})
+            
+            if not isinstance(schedules, dict):
+                continue
+                
+            for date_key, day_schedule in schedules.items():
+                # Check if date is within range
+                if date_key < from_date or date_key > to_date:
+                    continue
+                
+                if not isinstance(day_schedule, dict):
+                    continue
+                
+                # Check shifts
+                shifts = day_schedule.get("shifts", [])
+                for shift in shifts:
+                    volunteers = shift.get("volunteers", [])
+                    for vol in volunteers:
+                        vol_username = vol.get("username", "")
+                        if vol_username and vol_username.lower() == username.lower():
+                            results.append({
+                                "pantry_id": pantry_id,
+                                "pantry_name": pantry_name,
+                                "date": date_key,
+                                "shift": shift.get("shift", "Unknown Shift"),
+                                "time": shift.get("time", "")
+                            })
+                
+                # Check general volunteers
+                general_volunteers = day_schedule.get("general_volunteers", [])
+                for vol in general_volunteers:
+                    vol_username = vol.get("username", "")
+                    if vol_username and vol_username.lower() == username.lower():
+                        results.append({
+                            "pantry_id": pantry_id,
+                            "pantry_name": pantry_name,
+                            "date": date_key,
+                            "shift": "General",
+                            "time": "Flexible"
+                        })
+        
+        return results
+    
+    def check_user_scheduled_on_date(self, username: str, date_key: str, exclude_pantry_id=None):
+        """
+        Check if a user is already scheduled at any pantry on a given date.
+        Returns {scheduled: bool, pantry_name: str or None, pantry_id: str or None}
+        """
+        from bson import ObjectId
+        
+        pantries = list(self.collection.find({}, {"_id": 1, "name": 1, "schedules": 1}))
+        
+        for pantry in pantries:
+            pantry_id = str(pantry["_id"])
+            
+            # Skip the pantry we're trying to add to (if specified)
+            if exclude_pantry_id and pantry_id == str(exclude_pantry_id):
+                continue
+                
+            pantry_name = pantry.get("name", "Unknown Pantry")
+            schedules = pantry.get("schedules", {})
+            
+            if not isinstance(schedules, dict):
+                continue
+            
+            day_schedule = schedules.get(date_key)
+            if not day_schedule or not isinstance(day_schedule, dict):
+                continue
+            
+            # Check shifts
+            shifts = day_schedule.get("shifts", [])
+            for shift in shifts:
+                volunteers = shift.get("volunteers", [])
+                for vol in volunteers:
+                    vol_username = vol.get("username", "")
+                    if vol_username and vol_username.lower() == username.lower():
+                        return {
+                            "scheduled": True,
+                            "pantry_name": pantry_name,
+                            "pantry_id": pantry_id
+                        }
+            
+            # Check general volunteers
+            general_volunteers = day_schedule.get("general_volunteers", [])
+            for vol in general_volunteers:
+                vol_username = vol.get("username", "")
+                if vol_username and vol_username.lower() == username.lower():
+                    return {
+                        "scheduled": True,
+                        "pantry_name": pantry_name,
+                        "pantry_id": pantry_id
+                    }
+        
+        return {"scheduled": False, "pantry_name": None, "pantry_id": None}
 
     def create_pantry(self, name, address, email, phone_number, password, username=None, website=None):
         pantry_data = {
@@ -128,20 +235,177 @@ class pantry_model:
         return pantry.get("stream", [])
 
     # --- Volunteer Schedules ---
-    def get_schedule_for_date(self, pantry_id, date_key: str):
-        """Return schedule array for a specific date key (YYYY-MM-DD)."""
+    def get_schedule_for_date(self, pantry_id, date_key: str, auto_generate: bool = True):
+        """
+        Return schedule for a specific date key (YYYY-MM-DD).
+        New format: { shifts: [...], general_volunteers: [...] }
+        If auto_generate is True and schedule doesn't exist, generate from default template.
+        """
         pantry = self.collection.find_one(
             {"_id": pantry_id},
-            {f"schedules.{date_key}": 1, "_id": 0}
+            {f"schedules.{date_key}": 1, "schedule_settings": 1, "_id": 0}
         )
+        
         schedules = pantry.get("schedules", {}) if pantry else {}
-        return schedules.get(date_key, [])
+        existing_schedule = schedules.get(date_key)
+        
+        # If schedule exists, return it (handle legacy format)
+        if existing_schedule is not None:
+            # Handle legacy format (array of shifts)
+            if isinstance(existing_schedule, list):
+                return {
+                    "shifts": existing_schedule,
+                    "general_volunteers": []
+                }
+            return existing_schedule
+        
+        # If no schedule exists and auto_generate is enabled, try to create from default
+        if auto_generate:
+            generated = self._auto_generate_schedule(pantry_id, date_key, pantry)
+            if generated:
+                return generated
+        
+        # Return empty schedule structure
+        return {"shifts": [], "general_volunteers": []}
+    
+    def _auto_generate_schedule(self, pantry_id, date_key: str, pantry_doc=None):
+        """
+        Auto-generate a schedule from the default template if conditions are met.
+        Uses upsert with $setOnInsert for idempotent, concurrency-safe generation.
+        """
+        if pantry_doc is None:
+            pantry_doc = self.collection.find_one(
+                {"_id": pantry_id},
+                {"schedule_settings": 1}
+            )
+        
+        if not pantry_doc:
+            return None
+        
+        settings = pantry_doc.get("schedule_settings", {})
+        
+        # Check if scheduling is enabled and default schedule should be used
+        if not settings.get("schedulingEnabled", True):
+            return None
+        if not settings.get("useDefaultSchedule", False):
+            return None
+        
+        # Check if date is an open day
+        try:
+            date_obj = datetime.strptime(date_key, "%Y-%m-%d")
+            day_of_week = date_obj.weekday()  # 0=Monday, 6=Sunday
+            # Convert to JS format (0=Sunday, 6=Saturday)
+            js_day_of_week = (day_of_week + 1) % 7
+        except ValueError:
+            return None
+        
+        open_days = settings.get("openDays", [1, 2, 3, 4, 5])  # Default Mon-Fri
+        if js_day_of_week not in open_days:
+            return None
+        
+        # Check if date is excluded
+        excluded_dates = settings.get("excludedDates", [])
+        if date_key in excluded_dates:
+            return None
+        
+        # Get default schedule template
+        default_schedule = settings.get("defaultSchedule", [])
+        if not default_schedule:
+            return None
+        
+        # Create schedule from template (deep copy, clear volunteers)
+        new_shifts = []
+        for i, shift in enumerate(default_schedule):
+            new_shifts.append({
+                "id": shift.get("id", i + 1),
+                "time": shift.get("time", ""),
+                "shift": shift.get("shift", ""),
+                "volunteers": []  # Start with no volunteers
+            })
+        
+        new_schedule = {
+            "shifts": new_shifts,
+            "general_volunteers": []
+        }
+        
+        # Use $setOnInsert pattern for idempotent generation
+        # This only sets the value if the field doesn't exist
+        result = self.collection.update_one(
+            {"_id": pantry_id, f"schedules.{date_key}": {"$exists": False}},
+            {"$set": {f"schedules.{date_key}": new_schedule}}
+        )
+        
+        if result.modified_count > 0:
+            return new_schedule
+        
+        # If not modified, the schedule might already exist (race condition)
+        # Fetch and return whatever is there now
+        pantry = self.collection.find_one(
+            {"_id": pantry_id},
+            {f"schedules.{date_key}": 1}
+        )
+        if pantry:
+            schedules = pantry.get("schedules", {})
+            return schedules.get(date_key, new_schedule)
+        
+        return new_schedule
+    
+    def ensure_schedules_for_range(self, pantry_id, from_date: str, to_date: str):
+        """
+        Ensure schedules exist for all eligible days in a date range.
+        Only generates missing schedules from the default template.
+        """
+        pantry = self.collection.find_one(
+            {"_id": pantry_id},
+            {"schedules": 1, "schedule_settings": 1}
+        )
+        
+        if not pantry:
+            return 0
+        
+        settings = pantry.get("schedule_settings", {})
+        if not settings.get("schedulingEnabled", True):
+            return 0
+        if not settings.get("useDefaultSchedule", False):
+            return 0
+        
+        existing_schedules = pantry.get("schedules", {})
+        if not isinstance(existing_schedules, dict):
+            existing_schedules = {}
+        
+        generated_count = 0
+        current_date = datetime.strptime(from_date, "%Y-%m-%d")
+        end_date = datetime.strptime(to_date, "%Y-%m-%d")
+        
+        while current_date <= end_date:
+            date_key = current_date.strftime("%Y-%m-%d")
+            
+            # Skip if already exists
+            if date_key not in existing_schedules:
+                result = self._auto_generate_schedule(pantry_id, date_key, pantry)
+                if result:
+                    generated_count += 1
+            
+            current_date += timedelta(days=1)
+        
+        return generated_count
 
-    def save_schedule_for_date(self, pantry_id, date_key: str, schedule_array):
-        """Save schedule array for a specific date key (YYYY-MM-DD)."""
+    def save_schedule_for_date(self, pantry_id, date_key: str, schedule_data):
+        """
+        Save schedule for a specific date key (YYYY-MM-DD).
+        Accepts new format: { shifts: [...], general_volunteers: [...] }
+        Or legacy format: [...] (array of shifts)
+        """
+        # Handle legacy format (array of shifts)
+        if isinstance(schedule_data, list):
+            schedule_data = {
+                "shifts": schedule_data,
+                "general_volunteers": []
+            }
+        
         result = self.collection.update_one(
             {"_id": pantry_id},
-            {"$set": {f"schedules.{date_key}": schedule_array}}
+            {"$set": {f"schedules.{date_key}": schedule_data}}
         )
         return result.matched_count > 0
 
@@ -195,7 +459,7 @@ class pantry_model:
         return result.matched_count > 0
     
     def get_pantries(self):
-        """Swift stream view functionality"""
+        """Swift stream view functionality - includes schedule_settings for volunteer scheduling"""
         return list(
             self.collection.aggregate([
                 {
@@ -240,8 +504,9 @@ class pantry_model:
                         "email":1,
                         "phone_number":1,
                         "website":1,
-                        "stock":1, #return all stock items (removed slice limitation)
+                        "stock":1,
                         "stream":1,
+                        "schedule_settings":1,  # Include schedule settings for volunteer scheduling
                     }
                 }
             ])


### PR DESCRIPTION
# Volunteer Scheduling Feature

> V1.2 is now completed and submitted to App Store Connect.
## Server:
- Auto-generation of schedules 7 days in advance from default template (idempotent)
- User conflict checking (can't volunteer at multiple pantries same day)
- General volunteers section alongside shifts
- Cleanup of past schedules
## React Dashboard:
- Prominent "Default Shifts & Schedule Setup" section (no longer hidden)
- Dashboard shows actual default schedule with alert if not configured
- General volunteers section for each day
- Removed all "Role" fields
- Conflict validation before saving
# App:
- "Your Week at a Glance" showing next 7 days of scheduled shifts
- Custom date selector with excluded days grayed out
- Plus/Join button on each shift and general volunteers section
- Conflict checking before adding self to schedule
- Removed all role functionality
- Volunteer account checks - must sign up as volunteer before accessing schedule, can't re-register if already signed up